### PR TITLE
fix: bump CDK version to 2.232.1

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -148,12 +148,12 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.198.0",
+      "version": "^2.232.1",
       "type": "peer"
     },
     {
       "name": "constructs",
-      "version": "^10.4.2",
+      "version": "^10.4.4",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -7,8 +7,8 @@ const project = new AwsCdkConstructLibrary({
   license: "MIT",
   copyrightOwner: "Norberhuis Onderneming B.V.",
 
-  cdkVersion: "2.198.0",
-  constructsVersion: "10.4.2",
+  cdkVersion: "2.232.1",
+  constructsVersion: "10.4.4",
 
   name: "@rocketleap/cdk-organizations",
   description: "Manage AWS organizations, organizational units (OU), accounts and service control policies (SCP).",

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2025 Pepperize UG (haftungsbeschränkt)
+Copyright (c) 2026 Pepperize UG (haftungsbeschränkt)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -52,13 +52,13 @@
     "@types/sinon": "^10.0.13",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "aws-cdk-lib": "2.198.0",
+    "aws-cdk-lib": "2.232.1",
     "aws-lambda": "^1.0.7",
     "aws-sdk": "^2.1328.0",
     "aws-sdk-mock": "^5.8.0",
     "cdk-nag": "^2.22.27",
     "commit-and-tag-version": "^12",
-    "constructs": "10.4.2",
+    "constructs": "10.4.4",
     "esbuild": "^0.17.11",
     "eslint": "^9",
     "eslint-config-prettier": "^8.7.0",
@@ -81,8 +81,8 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.198.0",
-    "constructs": "^10.4.2"
+    "aws-cdk-lib": "^2.232.1",
+    "constructs": "^10.4.4"
   },
   "dependencies": {
     "pascal-case": "^3.1.2"

--- a/test/__snapshots__/account.test.ts.snap
+++ b/test/__snapshots__/account.test.ts.snap
@@ -193,7 +193,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/90c39385c0b0221ebd4bf238126ddbf1800d13903fb5171c5b68dd7b81593405.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/98896b362d036a5c493c2b210cbcf681ce6807e122e6e88de8f4c2aa71b84abb.json",
             ],
           ],
         },
@@ -212,7 +212,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/18cbdf1d711377ad2fe614944d4e439053805c916f0a8acbba0d52662ae599d3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/f87a9102ea4127f9c7f4fbfa16262acf13cb81f315cb92a8beec5d7c1bc868a3.json",
             ],
           ],
         },
@@ -231,7 +231,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c60a8751aef1c3f0621aacf9ac86c3c35f02def937b9617548a70c8910069b96.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
             ],
           ],
         },

--- a/test/__snapshots__/account.test.ts.snap
+++ b/test/__snapshots__/account.test.ts.snap
@@ -193,7 +193,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/98896b362d036a5c493c2b210cbcf681ce6807e122e6e88de8f4c2aa71b84abb.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/729df2c048d490496a599d4d04ddd2795d75fa7df9d278cb1a5a0f38207abfb7.json",
             ],
           ],
         },
@@ -212,7 +212,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f87a9102ea4127f9c7f4fbfa16262acf13cb81f315cb92a8beec5d7c1bc868a3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/cfc53a95b10804cd435f157f9b1a1e28bebcca3503583081a4e10b725a834185.json",
             ],
           ],
         },
@@ -231,7 +231,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/8092c91ab70399cff5986084c5efde2801867874ca7e682a22969175a68dbe55.json",
             ],
           ],
         },

--- a/test/__snapshots__/delegated-administrator.test.ts.snap
+++ b/test/__snapshots__/delegated-administrator.test.ts.snap
@@ -184,7 +184,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/90c39385c0b0221ebd4bf238126ddbf1800d13903fb5171c5b68dd7b81593405.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/98896b362d036a5c493c2b210cbcf681ce6807e122e6e88de8f4c2aa71b84abb.json",
             ],
           ],
         },
@@ -203,7 +203,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c60a8751aef1c3f0621aacf9ac86c3c35f02def937b9617548a70c8910069b96.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
             ],
           ],
         },

--- a/test/__snapshots__/delegated-administrator.test.ts.snap
+++ b/test/__snapshots__/delegated-administrator.test.ts.snap
@@ -184,7 +184,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/98896b362d036a5c493c2b210cbcf681ce6807e122e6e88de8f4c2aa71b84abb.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/729df2c048d490496a599d4d04ddd2795d75fa7df9d278cb1a5a0f38207abfb7.json",
             ],
           ],
         },
@@ -203,7 +203,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/8092c91ab70399cff5986084c5efde2801867874ca7e682a22969175a68dbe55.json",
             ],
           ],
         },

--- a/test/__snapshots__/dependency-chain.test.ts.snap
+++ b/test/__snapshots__/dependency-chain.test.ts.snap
@@ -381,7 +381,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/90c39385c0b0221ebd4bf238126ddbf1800d13903fb5171c5b68dd7b81593405.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/98896b362d036a5c493c2b210cbcf681ce6807e122e6e88de8f4c2aa71b84abb.json",
             ],
           ],
         },
@@ -400,7 +400,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/18cbdf1d711377ad2fe614944d4e439053805c916f0a8acbba0d52662ae599d3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/f87a9102ea4127f9c7f4fbfa16262acf13cb81f315cb92a8beec5d7c1bc868a3.json",
             ],
           ],
         },
@@ -419,7 +419,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c60a8751aef1c3f0621aacf9ac86c3c35f02def937b9617548a70c8910069b96.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
             ],
           ],
         },
@@ -1028,7 +1028,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/90c39385c0b0221ebd4bf238126ddbf1800d13903fb5171c5b68dd7b81593405.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/98896b362d036a5c493c2b210cbcf681ce6807e122e6e88de8f4c2aa71b84abb.json",
             ],
           ],
         },
@@ -1047,7 +1047,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/18cbdf1d711377ad2fe614944d4e439053805c916f0a8acbba0d52662ae599d3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/f87a9102ea4127f9c7f4fbfa16262acf13cb81f315cb92a8beec5d7c1bc868a3.json",
             ],
           ],
         },
@@ -1066,7 +1066,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c60a8751aef1c3f0621aacf9ac86c3c35f02def937b9617548a70c8910069b96.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
             ],
           ],
         },

--- a/test/__snapshots__/dependency-chain.test.ts.snap
+++ b/test/__snapshots__/dependency-chain.test.ts.snap
@@ -381,7 +381,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/98896b362d036a5c493c2b210cbcf681ce6807e122e6e88de8f4c2aa71b84abb.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/729df2c048d490496a599d4d04ddd2795d75fa7df9d278cb1a5a0f38207abfb7.json",
             ],
           ],
         },
@@ -400,7 +400,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f87a9102ea4127f9c7f4fbfa16262acf13cb81f315cb92a8beec5d7c1bc868a3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/cfc53a95b10804cd435f157f9b1a1e28bebcca3503583081a4e10b725a834185.json",
             ],
           ],
         },
@@ -419,7 +419,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/8092c91ab70399cff5986084c5efde2801867874ca7e682a22969175a68dbe55.json",
             ],
           ],
         },
@@ -1028,7 +1028,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/98896b362d036a5c493c2b210cbcf681ce6807e122e6e88de8f4c2aa71b84abb.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/729df2c048d490496a599d4d04ddd2795d75fa7df9d278cb1a5a0f38207abfb7.json",
             ],
           ],
         },
@@ -1047,7 +1047,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f87a9102ea4127f9c7f4fbfa16262acf13cb81f315cb92a8beec5d7c1bc868a3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/cfc53a95b10804cd435f157f9b1a1e28bebcca3503583081a4e10b725a834185.json",
             ],
           ],
         },
@@ -1066,7 +1066,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/8092c91ab70399cff5986084c5efde2801867874ca7e682a22969175a68dbe55.json",
             ],
           ],
         },

--- a/test/__snapshots__/enable-policy-type.test.ts.snap
+++ b/test/__snapshots__/enable-policy-type.test.ts.snap
@@ -226,7 +226,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/18cbdf1d711377ad2fe614944d4e439053805c916f0a8acbba0d52662ae599d3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/f87a9102ea4127f9c7f4fbfa16262acf13cb81f315cb92a8beec5d7c1bc868a3.json",
             ],
           ],
         },
@@ -245,7 +245,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c60a8751aef1c3f0621aacf9ac86c3c35f02def937b9617548a70c8910069b96.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
             ],
           ],
         },

--- a/test/__snapshots__/enable-policy-type.test.ts.snap
+++ b/test/__snapshots__/enable-policy-type.test.ts.snap
@@ -226,7 +226,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f87a9102ea4127f9c7f4fbfa16262acf13cb81f315cb92a8beec5d7c1bc868a3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/cfc53a95b10804cd435f157f9b1a1e28bebcca3503583081a4e10b725a834185.json",
             ],
           ],
         },
@@ -245,7 +245,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/8092c91ab70399cff5986084c5efde2801867874ca7e682a22969175a68dbe55.json",
             ],
           ],
         },

--- a/test/__snapshots__/integ.default.test.ts.snap
+++ b/test/__snapshots__/integ.default.test.ts.snap
@@ -1678,7 +1678,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/2bdba598a67ae8c7ab30d5a5c0d522a502628c2f3ecdb3a972d923b483313d38.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d783da0ffd24710132dbf6f0e75488b9c3e785075645e4bdbfb14dbb297a3d69.json",
             ],
           ],
         },
@@ -1697,7 +1697,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/3da9608c04ca9373f9f39e143c90efff96a5dbb69c34b66b5a73bfb3fec89271.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/067af2a34837629f695c62b18324695aa99bb38e3297466dd50a0868f9711fc3.json",
             ],
           ],
         },
@@ -1716,7 +1716,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/a0925d721dbd4ca56fcc794b77e18f71aab3def52d905aedb4612120d8989ede.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/896bfdf43f0ebc52cddba9b2004040e8d3f1141832393d0c661a467f5e22a823.json",
             ],
           ],
         },
@@ -1735,7 +1735,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/84559c4c9632c4d7572a1d8a6e7209638931ef5eeaf23857fd8401dcafc887bb.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/96a68d93ffa770c2d770a1ed8602b32bf2c96afc099ff47cf7e1da817d5e7b13.json",
             ],
           ],
         },

--- a/test/__snapshots__/integ.default.test.ts.snap
+++ b/test/__snapshots__/integ.default.test.ts.snap
@@ -1678,7 +1678,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/d783da0ffd24710132dbf6f0e75488b9c3e785075645e4bdbfb14dbb297a3d69.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/2c17ed62f8a3622b47d07644ce459f0e6ae610c94fe03cb3271162bacc29121b.json",
             ],
           ],
         },
@@ -1697,7 +1697,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/067af2a34837629f695c62b18324695aa99bb38e3297466dd50a0868f9711fc3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/a1363248be680ee63dbd41816f2c01ac45533ac51da79750b0a9d2d84836bedf.json",
             ],
           ],
         },
@@ -1716,7 +1716,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/896bfdf43f0ebc52cddba9b2004040e8d3f1141832393d0c661a467f5e22a823.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/c836926ef573b52e871e1ba6b99cb87cc1a33e29a0bc055264d7a38be997b701.json",
             ],
           ],
         },
@@ -1735,7 +1735,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/96a68d93ffa770c2d770a1ed8602b32bf2c96afc099ff47cf7e1da817d5e7b13.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/62e68e97bd53bdd1d586d0c3a7fa1b2faae2c8003f666e8a65062d9778a150e1.json",
             ],
           ],
         },

--- a/test/__snapshots__/organization.test.ts.snap
+++ b/test/__snapshots__/organization.test.ts.snap
@@ -146,7 +146,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f87a9102ea4127f9c7f4fbfa16262acf13cb81f315cb92a8beec5d7c1bc868a3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/cfc53a95b10804cd435f157f9b1a1e28bebcca3503583081a4e10b725a834185.json",
             ],
           ],
         },
@@ -165,7 +165,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/8092c91ab70399cff5986084c5efde2801867874ca7e682a22969175a68dbe55.json",
             ],
           ],
         },

--- a/test/__snapshots__/organization.test.ts.snap
+++ b/test/__snapshots__/organization.test.ts.snap
@@ -146,7 +146,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/18cbdf1d711377ad2fe614944d4e439053805c916f0a8acbba0d52662ae599d3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/f87a9102ea4127f9c7f4fbfa16262acf13cb81f315cb92a8beec5d7c1bc868a3.json",
             ],
           ],
         },
@@ -165,7 +165,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c60a8751aef1c3f0621aacf9ac86c3c35f02def937b9617548a70c8910069b96.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
             ],
           ],
         },

--- a/test/__snapshots__/organizational-unit.test.ts.snap
+++ b/test/__snapshots__/organizational-unit.test.ts.snap
@@ -198,7 +198,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/18cbdf1d711377ad2fe614944d4e439053805c916f0a8acbba0d52662ae599d3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/f87a9102ea4127f9c7f4fbfa16262acf13cb81f315cb92a8beec5d7c1bc868a3.json",
             ],
           ],
         },
@@ -217,7 +217,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c8cc7d88013565bcb0db3b7887c682edad94a41a1786f7ef1785306907e3a6fc.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/b0ff493066d4a94077901f5c0ea3b7a67ca7473cd88b0cdc64f8c399e726e699.json",
             ],
           ],
         },
@@ -236,7 +236,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c60a8751aef1c3f0621aacf9ac86c3c35f02def937b9617548a70c8910069b96.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
             ],
           ],
         },

--- a/test/__snapshots__/organizational-unit.test.ts.snap
+++ b/test/__snapshots__/organizational-unit.test.ts.snap
@@ -198,7 +198,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f87a9102ea4127f9c7f4fbfa16262acf13cb81f315cb92a8beec5d7c1bc868a3.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/cfc53a95b10804cd435f157f9b1a1e28bebcca3503583081a4e10b725a834185.json",
             ],
           ],
         },
@@ -217,7 +217,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/b0ff493066d4a94077901f5c0ea3b7a67ca7473cd88b0cdc64f8c399e726e699.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0460232cec1856f9bb1cbc4988741f0563cfb4a4008fd4092c4ed1488a6ce035.json",
             ],
           ],
         },
@@ -236,7 +236,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/8092c91ab70399cff5986084c5efde2801867874ca7e682a22969175a68dbe55.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy-attachment.test.ts.snap
+++ b/test/__snapshots__/policy-attachment.test.ts.snap
@@ -305,7 +305,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/98896b362d036a5c493c2b210cbcf681ce6807e122e6e88de8f4c2aa71b84abb.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/729df2c048d490496a599d4d04ddd2795d75fa7df9d278cb1a5a0f38207abfb7.json",
             ],
           ],
         },
@@ -324,7 +324,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/8092c91ab70399cff5986084c5efde2801867874ca7e682a22969175a68dbe55.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy-attachment.test.ts.snap
+++ b/test/__snapshots__/policy-attachment.test.ts.snap
@@ -305,7 +305,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/90c39385c0b0221ebd4bf238126ddbf1800d13903fb5171c5b68dd7b81593405.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/98896b362d036a5c493c2b210cbcf681ce6807e122e6e88de8f4c2aa71b84abb.json",
             ],
           ],
         },
@@ -324,7 +324,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c60a8751aef1c3f0621aacf9ac86c3c35f02def937b9617548a70c8910069b96.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy.test.ts.snap
+++ b/test/__snapshots__/policy.test.ts.snap
@@ -137,7 +137,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/8092c91ab70399cff5986084c5efde2801867874ca7e682a22969175a68dbe55.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy.test.ts.snap
+++ b/test/__snapshots__/policy.test.ts.snap
@@ -137,7 +137,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c60a8751aef1c3f0621aacf9ac86c3c35f02def937b9617548a70c8910069b96.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/85519f0c8f90ccf7894b84d953b732c1d6a2db4bb75f3baa25482fc5fe98defd.json",
             ],
           ],
         },

--- a/test/__snapshots__/tag-resource.test.ts.snap
+++ b/test/__snapshots__/tag-resource.test.ts.snap
@@ -28,7 +28,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/9889b9cde3e5339ce56f6159ceccafab81a08ef2173398b0ef3c8d31facce783.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/072f63be42ade77e74b345f1eee1f6f63d4d7016f5325840e84c0a8f9b39f40d.json",
             ],
           ],
         },

--- a/test/__snapshots__/tag-resource.test.ts.snap
+++ b/test/__snapshots__/tag-resource.test.ts.snap
@@ -28,7 +28,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/072f63be42ade77e74b345f1eee1f6f63d4d7016f5325840e84c0a8f9b39f40d.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/cfa833893de07e5da6945dc4bd62413d063a6922eaf70a63032b569fbea66f7f.json",
             ],
           ],
         },

--- a/test/cdk-nag.test.ts
+++ b/test/cdk-nag.test.ts
@@ -20,6 +20,10 @@ describe("cdk-nag", () => {
         },
         { id: "AwsSolutions-L1", reason: "Custom resource providers bundled with the sdk" },
         {
+          id: "AwsSolutions-SF1",
+          reason: "CloudWatch logging not configurable for Provider framework's internal waiter-state-machine",
+        },
+        {
           id: "AwsSolutions-SF2",
           reason: "X-Ray tracing not configurable for Provider framework's internal waiter-state-machine",
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,23 +21,23 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
-"@aws-cdk/asset-awscli-v1@2.2.237":
-  version "2.2.237"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.237.tgz#d3356aaf3f73e34982ae289b7e4441e20d58497a"
-  integrity sha512-OlXylbXI52lboFVJBFLae+WB99qWmI121x/wXQHEMj2RaVNVbWE+OAHcDk2Um1BitUQCaTf9ki57B0Fuqx0Rvw==
+"@aws-cdk/asset-awscli-v1@2.2.242":
+  version "2.2.242"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz#235cb25b6d1ad26975b0095c0d6ee84309adae5c"
+  integrity sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==
 
 "@aws-cdk/asset-node-proxy-agent-v6@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz#6d3c7860354d4856a7e75375f2f0ecab313b4989"
   integrity sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==
 
-"@aws-cdk/cloud-assembly-schema@^41.2.0":
-  version "41.2.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz#c1ef513e1cc0528dbc05948ae39d5631306af423"
-  integrity sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==
+"@aws-cdk/cloud-assembly-schema@^48.20.0":
+  version "48.20.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.20.0.tgz#a2b60373cfbe228f901f62f0d7e2c5e2fe40702d"
+  integrity sha512-+eeiav9LY4wbF/EFuCt/vfvi/Zoxo8bf94PW5clbMraChEliq83w4TbRVy0jB9jE0v1ooFTtIjSQkowSPkfISg==
   dependencies:
     jsonschema "~1.4.1"
-    semver "^7.7.1"
+    semver "^7.7.2"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.27.1":
   version "7.27.1"
@@ -1554,23 +1554,23 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@2.198.0:
-  version "2.198.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.198.0.tgz#56b4da4692517c13b76acc06e3a2ed22bb6ef0f0"
-  integrity sha512-CyZ+lnRsCsLskzQLPO0EiGl5EVcLluhfa67df3b8/gJfsm+91SHJa75OH+ymdGtUp5Vn/MWUPsujw0EhWMfsIQ==
+aws-cdk-lib@2.232.1:
+  version "2.232.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.232.1.tgz#cd2ded9ef33d06d054f96213b71cab356b8e06ba"
+  integrity sha512-F1vNcpWBo85pSxa0DJ5DO4k7Ok4vVp0vh1cFO4Y12LLX07ixOcnJn/6B97/XVC0fgZNvzPx/sYgioEd0u8oKkQ==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "2.2.237"
+    "@aws-cdk/asset-awscli-v1" "2.2.242"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"
-    "@aws-cdk/cloud-assembly-schema" "^41.2.0"
+    "@aws-cdk/cloud-assembly-schema" "^48.20.0"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
-    fs-extra "^11.3.0"
+    fs-extra "^11.3.2"
     ignore "^5.3.2"
     jsonschema "^1.5.0"
     mime-types "^2.1.35"
     minimatch "^3.1.2"
     punycode "^2.3.1"
-    semver "^7.7.2"
+    semver "^7.7.3"
     table "^6.9.0"
     yaml "1.10.2"
 
@@ -1988,7 +1988,12 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
-constructs@10.4.2, constructs@^10.0.0:
+constructs@10.4.4:
+  version "10.4.4"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.4.4.tgz#e128541bca10d00f284728e8869138fc7d1d76bf"
+  integrity sha512-lP0qC1oViYf1cutHo9/KQ8QL637f/W29tDmv/6sy35F5zs+MD9f66nbAAIjicwc7fwyuF3rkg6PhZh4sfvWIpA==
+
+constructs@^10.0.0:
   version "10.4.2"
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.4.2.tgz#e875a78bef932cca12ea63965969873a25c1c132"
   integrity sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==
@@ -2977,10 +2982,10 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.3.0:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.0.tgz#0daced136bbaf65a555a326719af931adc7a314d"
-  integrity sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==
+fs-extra@^11.3.2:
+  version "11.3.4"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.4.tgz#ab6934eca8bcf6f7f6b82742e33591f86301d6fc"
+  integrity sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
@@ -5517,6 +5522,11 @@ semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.7.3:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
 set-function-length@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
## Summary
- Bumps aws-cdk-lib from 2.198.0 to 2.232.1 and constructs from 10.4.2 to 10.4.4
- Aligns CDK version with platform projects
- Lambda runtime remains at nodejs22.x (projen-generated)

Ref: rocketleap/Roadmap#48